### PR TITLE
Parse command start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## New features
 
+* `log` and `stat` can now show emerge command start events
+  - Not end events, as `emerge.log` doesn't provide enough info to make this reliable
+* `--from` and `--to` now accept a command index as argument
+  - `--from=1command` or `-fc` is roughly equivalent to qlop's `--lastmerge`
 * `predict` now displays emerge proces tree instead of just top proces
   - Bevahvior configurable with `--pdepth`, `--pwidth`
   - Format is a bit nicer and more colorful

--- a/benches/exec_compare.rs
+++ b/benches/exec_compare.rs
@@ -61,6 +61,8 @@ fn main() {
         ("ld2", "genlop", &["-f","{emerge.log}","-l", "--date","2020-10-01","--date","2020-10-31"], None),
         ("ld2", "qlop",   &["-f","{emerge.log}","-mv","--date","2020-10-01","--date","2020-10-31"], None),
         ("ld2", "emlop",  &["-F","{emerge.log}","l",  "--from","2020-10-01","--to",  "2020-10-31"], None),
+        ("ldl", "qlop",   &["-f","{emerge.log}","-mv","--lastmerge"], None),
+        ("ldl", "emlop",  &["-F","{emerge.log}","l","--from=1c"],   None),
         // Force/prevent color output
         ("lc", "qlop",   &["-f","{emerge.log}","-mv","--color"],   None),
         ("lc", "emlop",  &["-F","{emerge.log}","l","--color=y"],   None),

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -89,16 +89,16 @@ For relative dates, genlop accepts fancy strings like "last month" or "2 weeks a
 less flexible but less verbose (no "ago" needed), and emlop only accepts a number of days/weeks/etc
 which can be abbreviated (for example "1 week, 3 days" -> "1w3d").
 
-|                                          | genlop      | qlop  | emlop       |
-|:-----------------------------------------|:-----------:|:-----:|:-----------:|
-| Limit log parsing by date                | yes         | yes   | yes         |
-| Limit log to number fisrt/last n entries | no          | no    | yes         |
-| Limit log to last emerge operation       | no          | yes   | no          |
-| Filter by package categ/name             | yes         | yes   | yes         |
-| Filter by sync repo                      | no          | no    | yes         |
-| Read filter list from file               | no          | yes   | no          |
-| Search modes                             | plain/regex | plain | plain/regex |
-| Default search mode                      | plain       | plain | regex       |
+|                                          | genlop      | qlop      | emlop       |
+|:-----------------------------------------|:-----------:|:---------:|:-----------:|
+| Limit log parsing by date                | yes         | yes       | yes         |
+| Limit log to number fisrt/last n entries | no          | no        | yes         |
+| Limit log to nth emerge operation        | no          | last only | yes         |
+| Filter by package categ/name             | yes         | yes       | yes         |
+| Filter by sync repo                      | no          | no        | yes         |
+| Read filter list from file               | no          | yes       | no          |
+| Search modes                             | plain/regex | plain     | plain/regex |
+| Default search mode                      | plain       | plain     | regex       |
 
 ## Merge time prediction
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -143,12 +143,37 @@ impl Times {
     }
 }
 
+/// Classify emerge commands by looking at their args.
+///
+/// Note that some commands don't get logged at all, so this enum is quite limited.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+enum ArgKind {
+    All,
+    Merge,
+    Clean,
+    Sync,
+}
+impl ArgKind {
+    fn new(args: &str) -> Self {
+        for arg in args.split_ascii_whitespace() {
+            match arg {
+                "--deselect" | "--unmerge" | "--clean" | "--depclean" => return Self::Clean,
+                "--sync" => return Self::Sync,
+                _ => (),
+            }
+        }
+        Self::Merge
+    }
+}
+
 /// Summary display of merge events
 ///
 /// First loop is like cmd_list but we store the merge time for each ebuild instead of printing it.
 /// Then we compute the stats per ebuild, and print that.
 pub fn cmd_stats(gc: Conf, sc: ConfStats) -> Result<bool, Error> {
     let hist = get_hist(&gc.logfile, gc.from, gc.to, sc.show, &sc.search, sc.exact)?;
+    let h = [sc.group.name(), "Logged emerges", "Install/Update", "Unmerge/Clean", "Sync"];
+    let mut tblc = Table::new(&gc).margin(1, " ").header(h);
     let h = [sc.group.name(), "Repo", "Syncs", "Total time", "Predict time"];
     let mut tbls = Table::new(&gc).align_left(0).align_left(1).margin(1, " ").header(h);
     let h = [sc.group.name(),
@@ -173,6 +198,7 @@ pub fn cmd_stats(gc: Conf, sc: ConfStats) -> Result<bool, Error> {
     let mut pkg_time: BTreeMap<String, (Times, Times)> = BTreeMap::new();
     let mut sync_start: Option<i64> = None;
     let mut sync_time: BTreeMap<String, Times> = BTreeMap::new();
+    let mut cmd_args: BTreeMap<ArgKind, usize> = BTreeMap::new();
     let mut nextts = 0;
     let mut curts = 0;
     for p in hist {
@@ -183,16 +209,20 @@ pub fn cmd_stats(gc: Conf, sc: ConfStats) -> Result<bool, Error> {
                 curts = t;
             } else if t > nextts {
                 let group = sc.group.at(curts, gc.date_offset);
-                cmd_stats_group(&gc, &sc, &mut tbls, &mut tblp, &mut tblt, group, &sync_time,
-                                &pkg_time);
+                cmd_stats_group(&gc, &sc, &mut tblc, &mut tbls, &mut tblp, &mut tblt, group,
+                                &cmd_args, &sync_time, &pkg_time);
                 sync_time.clear();
                 pkg_time.clear();
+                cmd_args.clear();
                 nextts = sc.group.next(t, gc.date_offset);
                 curts = t;
             }
         }
         match p {
-            Hist::CmdStart { .. } => todo!("CmdStart"),
+            Hist::CmdStart { args, .. } => {
+                *cmd_args.entry(ArgKind::All).or_insert(0) += 1;
+                *cmd_args.entry(ArgKind::new(&args)).or_insert(0) += 1;
+            },
             Hist::MergeStart { ts, key, .. } => {
                 merge_start.insert(key, ts);
             },
@@ -228,15 +258,20 @@ pub fn cmd_stats(gc: Conf, sc: ConfStats) -> Result<bool, Error> {
         }
     }
     let group = sc.group.at(curts, gc.date_offset);
-    cmd_stats_group(&gc, &sc, &mut tbls, &mut tblp, &mut tblt, group, &sync_time, &pkg_time);
+    cmd_stats_group(&gc, &sc, &mut tblc, &mut tbls, &mut tblp, &mut tblt, group, &cmd_args,
+                    &sync_time, &pkg_time);
     // Controlled drop to ensure table order and insert blank lines
-    let (es, ep, et) = (!tbls.is_empty(), !tblp.is_empty(), !tblt.is_empty());
+    let (ec, es, ep, et) = (!tblc.is_empty(), !tbls.is_empty(), !tblp.is_empty(), !tblt.is_empty());
+    drop(tblc);
+    if ec && es {
+        println!();
+    }
     drop(tbls);
-    if es && ep {
+    if (ec || es) && ep {
         println!();
     }
     drop(tblp);
-    if (es || ep) && et {
+    if (ec || es || ep) && et {
         println!();
     }
     drop(tblt);
@@ -247,12 +282,22 @@ pub fn cmd_stats(gc: Conf, sc: ConfStats) -> Result<bool, Error> {
 #[allow(clippy::too_many_arguments)]
 fn cmd_stats_group(gc: &Conf,
                    sc: &ConfStats,
+                   tblc: &mut Table<5>,
                    tbls: &mut Table<5>,
                    tblp: &mut Table<8>,
                    tblt: &mut Table<7>,
                    group: String,
+                   cmd_args: &BTreeMap<ArgKind, usize>,
                    sync_time: &BTreeMap<String, Times>,
                    pkg_time: &BTreeMap<String, (Times, Times)>) {
+    // Commands
+    if sc.show.cmd && !cmd_args.is_empty() {
+        tblc.row([&[&group],
+                  &[&gc.cnt, cmd_args.get(&ArgKind::All).unwrap_or(&0)],
+                  &[&gc.cnt, cmd_args.get(&ArgKind::Merge).unwrap_or(&0)],
+                  &[&gc.cnt, cmd_args.get(&ArgKind::Clean).unwrap_or(&0)],
+                  &[&gc.cnt, cmd_args.get(&ArgKind::Sync).unwrap_or(&0)]]);
+    }
     // Syncs
     if sc.show.sync && !sync_time.is_empty() {
         for (repo, time) in sync_time {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,12 +6,7 @@ use std::{collections::{BTreeMap, HashMap, HashSet},
 /// Straightforward display of merge events
 ///
 /// We store the start times in a hashmap to compute/print the duration when we reach a stop event.
-pub fn cmd_log(mut gc: Conf, sc: ConfLog) -> Result<bool, Error> {
-    if sc.lastmerge {
-        if let Some(t) = parse::get_cmd_times(&gc.logfile, gc.from, gc.to)?.last() {
-            gc.from = Some(*t);
-        }
-    }
+pub fn cmd_log(gc: Conf, sc: ConfLog) -> Result<bool, Error> {
     let hist = get_hist(&gc.logfile, gc.from, gc.to, sc.show, &sc.search, sc.exact)?;
     let mut merges: HashMap<String, i64> = HashMap::new();
     let mut unmerges: HashMap<String, i64> = HashMap::new();

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,12 @@ use std::{collections::{BTreeMap, HashMap, HashSet},
 /// Straightforward display of merge events
 ///
 /// We store the start times in a hashmap to compute/print the duration when we reach a stop event.
-pub fn cmd_log(gc: Conf, sc: ConfLog) -> Result<bool, Error> {
+pub fn cmd_log(mut gc: Conf, sc: ConfLog) -> Result<bool, Error> {
+    if sc.lastmerge {
+        if let Some(t) = parse::get_cmd_times(&gc.logfile, gc.from, gc.to)?.last() {
+            gc.from = Some(*t);
+        }
+    }
     let hist = get_hist(&gc.logfile, gc.from, gc.to, sc.show, &sc.search, sc.exact)?;
     let mut merges: HashMap<String, i64> = HashMap::new();
     let mut unmerges: HashMap<String, i64> = HashMap::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@ pub struct ConfLog {
     pub starttime: bool,
     pub first: usize,
     pub last: usize,
+    pub lastmerge: bool,
 }
 pub struct ConfPred {
     pub show: Show,
@@ -186,7 +187,8 @@ impl ConfLog {
                   exact: cli.get_flag("exact"),
                   starttime: sel!(cli, toml, log, starttime, (), false)?,
                   first: *cli.get_one("first").unwrap_or(&usize::MAX),
-                  last: *cli.get_one("last").unwrap_or(&usize::MAX) })
+                  last: *cli.get_one("last").unwrap_or(&usize::MAX),
+                  lastmerge: cli.get_flag("lastmerge") })
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -220,7 +220,7 @@ impl ConfPred {
 
 impl ConfStats {
     fn try_new(cli: &ArgMatches, toml: &Toml) -> Result<Self, Error> {
-        Ok(Self { show: sel!(cli, toml, stats, show, "ptsa", Show::p())?,
+        Ok(Self { show: sel!(cli, toml, stats, show, "cptsa", Show::p())?,
                   search: cli.get_many("search").unwrap_or_default().cloned().collect(),
                   exact: cli.get_flag("exact"),
                   lim: sel!(cli, toml, stats, limit, 1..=65000, 10)? as u16,

--- a/src/config.rs
+++ b/src/config.rs
@@ -181,7 +181,7 @@ impl Conf {
 
 impl ConfLog {
     fn try_new(cli: &ArgMatches, toml: &Toml) -> Result<Self, Error> {
-        Ok(Self { show: sel!(cli, toml, log, show, "musa", Show::m())?,
+        Ok(Self { show: sel!(cli, toml, log, show, "cmusa", Show::m())?,
                   search: cli.get_many("search").unwrap_or_default().cloned().collect(),
                   exact: cli.get_flag("exact"),
                   starttime: sel!(cli, toml, log, starttime, (), false)?,

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -81,7 +81,7 @@ pub fn build_cli() -> Command {
              2018-03-04|2018-03-04 12:34:56|2018-03-04T12:34: Absolute ISO date\n  \
              123456789:                                       Absolute unix timestamp\n  \
              1 year, 2 months|10d:                            Relative date\n  \
-             1c|2 commands                                    Emerge command";
+             1c|2 commands|c                                  Nth emerge command";
     let from = Arg::new("from").short('f')
                                .long("from")
                                .value_name("date")
@@ -95,7 +95,7 @@ pub fn build_cli() -> Command {
              2018-03-04|2018-03-04 12:34:56|2018-03-04T12:34: Absolute ISO date\n  \
              123456789:                                       Absolute unix timestamp\n  \
              1 year, 2 months|10d:                            Relative date\n  \
-             1c|2 commands                                    Emerge command";
+             1c|2 commands|c                                  Nth-last emerge command";
     let to = Arg::new("to").short('t')
                            .long("to")
                            .value_name("date")

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -43,17 +43,19 @@ pub fn build_cli() -> Command {
                                     u: Package unmerges\n  \
                                     s: Repository syncs\n  \
                                     a: All of the above");
-    let show_s = Arg::new("show").short('s')
-                                 .long("show")
-                                 .value_name("p,t,s,a")
-                                 .display_order(3)
-                                 .help_heading("Filter")
-                                 .help("Show (p)ackages, (t)otals, (s)yncs, and/or (a)ll")
-                                 .long_help("Show (any combination of)\n  \
-                                             p: Individual package merges/unmerges\n  \
-                                             t: Total package merges/unmerges\n  \
-                                             s: Repository syncs\n  \
-                                             a: All of the above");
+    let show_s =
+        Arg::new("show").short('s')
+                        .long("show")
+                        .value_name("c,p,t,s,a")
+                        .display_order(3)
+                        .help_heading("Filter")
+                        .help("Show (c)commands, (p)ackages, (t)otals, (s)yncs, and/or (a)ll")
+                        .long_help("Show (any combination of)\n  \
+                                    c: Emerge commands\n  \
+                                    p: Individual package merges/unmerges\n  \
+                                    t: Total package merges/unmerges\n  \
+                                    s: Repository syncs\n  \
+                                    a: All of the above");
     let show_p = Arg::new("show").short('s')
                                  .long("show")
                                  .value_name("e,m,t,a")

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -127,6 +127,11 @@ pub fn build_cli() -> Command {
                                .long_help("Show only the last <num> entries\n  \
                                            (empty)|1: last entry\n  \
                                            5:         last 5 entries\n");
+    let lastmerge = Arg::new("lastmerge").long("lastmerge")
+                                         .action(SetTrue)
+                                         .display_order(8)
+                                         .help_heading("Filter")
+                                         .help("Show only the last merge");
     let h = "Use main, backup, either, or no portage resume list\n\
              This is ignored if STDIN is a piped `emerge -p` output\n  \
              (default)|auto|a: Use main or backup resume list, if currently emerging\n  \
@@ -140,7 +145,7 @@ pub fn build_cli() -> Command {
                                    .hide_possible_values(true)
                                    .num_args(..=1)
                                    .default_missing_value("either")
-                                   .display_order(8)
+                                   .display_order(9)
                                    .help_heading("Filter")
                                    .help(h.split_once('\n').unwrap().0)
                                    .long_help(h);
@@ -337,6 +342,7 @@ pub fn build_cli() -> Command {
                                      .arg(starttime)
                                      .arg(&first)
                                      .arg(&last)
+                                     .arg(lastmerge)
                                      .arg(show_l)
                                      .arg(&exact)
                                      .arg(&pkg);

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -77,10 +77,11 @@ pub fn build_cli() -> Command {
                                              m: Package merges\n  \
                                              t: Totals\n  \
                                              a: All of the above");
-    let h = "Only parse log entries after <date>\n  \
+    let h = "Only parse log entries after <date/command>\n  \
              2018-03-04|2018-03-04 12:34:56|2018-03-04T12:34: Absolute ISO date\n  \
              123456789:                                       Absolute unix timestamp\n  \
-             1 year, 2 months|10d:                            Relative date";
+             1 year, 2 months|10d:                            Relative date\n  \
+             1c|2 commands                                    Emerge command";
     let from = Arg::new("from").short('f')
                                .long("from")
                                .value_name("date")
@@ -90,10 +91,11 @@ pub fn build_cli() -> Command {
                                .help_heading("Filter")
                                .help(h.split_once('\n').unwrap().0)
                                .long_help(h);
-    let h = "Only parse log entries before <date>\n  \
+    let h = "Only parse log entries before <date/command>\n  \
              2018-03-04|2018-03-04 12:34:56|2018-03-04T12:34: Absolute ISO date\n  \
              123456789:                                       Absolute unix timestamp\n  \
-             1 year, 2 months|10d:                            Relative date";
+             1 year, 2 months|10d:                            Relative date\n  \
+             1c|2 commands                                    Emerge command";
     let to = Arg::new("to").short('t')
                            .long("to")
                            .value_name("date")
@@ -127,11 +129,6 @@ pub fn build_cli() -> Command {
                                .long_help("Show only the last <num> entries\n  \
                                            (empty)|1: last entry\n  \
                                            5:         last 5 entries\n");
-    let lastmerge = Arg::new("lastmerge").long("lastmerge")
-                                         .action(SetTrue)
-                                         .display_order(8)
-                                         .help_heading("Filter")
-                                         .help("Show only the last merge");
     let h = "Use main, backup, either, or no portage resume list\n\
              This is ignored if STDIN is a piped `emerge -p` output\n  \
              (default)|auto|a: Use main or backup resume list, if currently emerging\n  \
@@ -342,7 +339,6 @@ pub fn build_cli() -> Command {
                                      .arg(starttime)
                                      .arg(&first)
                                      .arg(&last)
-                                     .arg(lastmerge)
                                      .arg(show_l)
                                      .arg(&exact)
                                      .arg(&pkg);

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -30,17 +30,19 @@ pub fn build_cli() -> Command {
                                              virtual/rust: Matches only `virtual/rust`\n  \
                                              RuSt:         Matches nothing (case-sensitive)\n  \
                                              ru:           Matches nothing (whole name only)");
-    let show_l = Arg::new("show").short('s')
-                                 .long("show")
-                                 .value_name("m,u,s,a")
-                                 .display_order(3)
-                                 .help_heading("Filter")
-                                 .help("Show (m)erges, (u)nmerges, (s)yncs, and/or (a)ll")
-                                 .long_help("Show (any combination of)\n  \
-                                             m: Package merges\n  \
-                                             u: Package unmerges\n  \
-                                             s: Repository syncs\n  \
-                                             a: All of the above");
+    let show_l =
+        Arg::new("show").short('s')
+                        .long("show")
+                        .value_name("c,m,u,s,a")
+                        .display_order(3)
+                        .help_heading("Filter")
+                        .help("Show (c)commands, (m)erges, (u)nmerges, (s)yncs, and/or (a)ll")
+                        .long_help("Show (any combination of)\n  \
+                                    c: Emerge command\n  \
+                                    m: Package merges\n  \
+                                    u: Package unmerges\n  \
+                                    s: Repository syncs\n  \
+                                    a: All of the above");
     let show_s = Arg::new("show").short('s')
                                  .long("show")
                                  .value_name("p,t,s,a")

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -184,6 +184,7 @@ impl ArgParse<String, bool> for OutStyle {
 
 #[derive(Clone, Copy)]
 pub struct Show {
+    pub cmd: bool,
     pub pkg: bool,
     pub tot: bool,
     pub sync: bool,
@@ -193,23 +194,48 @@ pub struct Show {
 }
 impl Show {
     pub const fn m() -> Self {
-        Self { pkg: false, tot: false, sync: false, merge: true, unmerge: false, emerge: false }
+        Self { cmd: false,
+               pkg: false,
+               tot: false,
+               sync: false,
+               merge: true,
+               unmerge: false,
+               emerge: false }
     }
     pub const fn emt() -> Self {
-        Self { pkg: false, tot: true, sync: false, merge: true, unmerge: false, emerge: true }
+        Self { cmd: false,
+               pkg: false,
+               tot: true,
+               sync: false,
+               merge: true,
+               unmerge: false,
+               emerge: true }
     }
     pub const fn p() -> Self {
-        Self { pkg: true, tot: false, sync: false, merge: false, unmerge: false, emerge: false }
+        Self { cmd: false,
+               pkg: true,
+               tot: false,
+               sync: false,
+               merge: false,
+               unmerge: false,
+               emerge: false }
     }
     pub const fn mt() -> Self {
-        Self { pkg: false, tot: true, sync: false, merge: true, unmerge: false, emerge: false }
+        Self { cmd: false,
+               pkg: false,
+               tot: true,
+               sync: false,
+               merge: true,
+               unmerge: false,
+               emerge: false }
     }
 }
 impl ArgParse<String, &'static str> for Show {
     fn parse(show: &String, valid: &'static str, src: &'static str) -> Result<Self, ArgError> {
         debug_assert!(valid.is_ascii()); // Because we use `chars()` we need to stick to ascii for `valid`.
         if show.chars().all(|c| valid.contains(c)) {
-            Ok(Self { pkg: show.contains('p') || show.contains('a'),
+            Ok(Self { cmd: show.contains('c') || show.contains('a'),
+                      pkg: show.contains('p') || show.contains('a'),
                       tot: show.contains('t') || show.contains('a'),
                       sync: show.contains('s') || show.contains('a'),
                       merge: show.contains('m') || show.contains('a'),
@@ -223,7 +249,8 @@ impl ArgParse<String, &'static str> for Show {
 impl std::fmt::Display for Show {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut sep = "";
-        for (b, s) in [(self.pkg, "pkg"),
+        for (b, s) in [(self.cmd, "command"),
+                       (self.pkg, "pkg"),
                        (self.tot, "total"),
                        (self.sync, "sync"),
                        (self.merge, "merge"),

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -74,32 +74,59 @@ pub fn epoch_now() -> i64 {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64
 }
 
+#[cfg_attr(test, derive(PartialEq, Debug))]
+#[derive(Clone, Copy)]
+pub enum TimeBound {
+    /// Unbounded
+    None,
+    /// Bound by unix timestamp
+    Unix(i64),
+    /// Bound by time of nth fist/last emerge command
+    Cmd(usize),
+}
+
 /// Parse datetime in various formats, returning unix timestamp
-impl ArgParse<String, UtcOffset> for i64 {
+impl ArgParse<String, UtcOffset> for TimeBound {
     fn parse(val: &String, offset: UtcOffset, src: &'static str) -> Result<Self, ArgError> {
         let s = val.trim();
         let et = match i64::from_str(s) {
-            Ok(i) => return Ok(i),
+            Ok(i) => return Ok(Self::Unix(i)),
             Err(et) => et,
         };
         let ea = match parse_date_yyyymmdd(s, offset) {
-            Ok(i) => return Ok(i),
+            Ok(i) => return Ok(Self::Unix(i)),
+            Err(ea) => ea,
+        };
+        let ec = match parse_command_num(s) {
+            Ok(i) => return Ok(Self::Cmd(i)),
             Err(ea) => ea,
         };
         match parse_date_ago(s) {
-            Ok(i) => Ok(i),
+            Ok(i) => Ok(Self::Unix(i)),
             Err(er) => {
-                let m = format!("Not a unix timestamp ({et}), absolute date ({ea}), or relative date ({er})");
+                let m = format!("Not a unix timestamp ({et}), absolute date ({ea}), relative date ({er}), or command ({ec})");
                 Err(ArgError::new(val, src).msg(m))
             },
         }
     }
 }
 
+/// Parse a command index
+fn parse_command_num(s: &str) -> Result<usize, Error> {
+    use atoi::FromRadix10;
+    match usize::from_radix_10(s.as_bytes()) {
+        (num, pos) if pos != 0 => match s[pos..].trim() {
+            "c" | "command" | "commands" => Ok(num),
+            _ => bail!("bad span {:?}", &s[pos..]),
+        },
+        _ => bail!("not a number"),
+    }
+}
+
 /// Parse a number of day/years/hours/etc in the past, relative to current time
 fn parse_date_ago(s: &str) -> Result<i64, Error> {
     if !s.chars().all(|c| c.is_alphanumeric() || c == ' ' || c == ',') {
-        bail!("Illegal char");
+        bail!("illegal char");
     }
     let mut now = OffsetDateTime::now_utc();
     let re = Regex::new("([0-9]+|[a-z]+)").expect("Bad date span regex");
@@ -138,7 +165,7 @@ fn parse_date_ago(s: &str) -> Result<i64, Error> {
     }
 
     if !at_least_one {
-        bail!("No token found");
+        bail!("no token found");
     }
     Ok(now.unix_timestamp())
 }
@@ -180,7 +207,7 @@ fn parse_date_yyyymmdd(s: &str, offset: UtcOffset) -> Result<i64, Error> {
         ]))
     ])?;
     if !rest.is_empty() {
-        bail!("Junk at end")
+        bail!("junk at end")
     }
     Ok(OffsetDateTime::try_from(p)?.unix_timestamp())
 }
@@ -299,8 +326,8 @@ mod test {
     fn parse_3339(s: &str) -> OffsetDateTime {
         OffsetDateTime::parse(s, &Rfc3339).expect(s)
     }
-    fn parse_date(s: &str, o: UtcOffset) -> Result<i64, ArgError> {
-        i64::parse(&String::from(s), o, "")
+    fn parse_date(s: &str, o: UtcOffset) -> Result<TimeBound, ArgError> {
+        TimeBound::parse(&String::from(s), o, "")
     }
     fn ts(t: OffsetDateTime) -> i64 {
         t.unix_timestamp()
@@ -315,22 +342,25 @@ mod test {
         let tz_utc = UtcOffset::UTC;
 
         // Absolute dates
-        assert_eq!(Ok(then), parse_date(" 1522713600 ", tz_utc));
-        assert_eq!(Ok(then), parse_date(" 2018-04-03 ", tz_utc));
-        assert_eq!(Ok(then + hour + min), parse_date("2018-04-03 01:01", tz_utc));
-        assert_eq!(Ok(then + hour + min + 1), parse_date("2018-04-03 01:01:01", tz_utc));
-        assert_eq!(Ok(then + hour + min + 1), parse_date("2018-04-03T01:01:01", tz_utc));
+        assert_eq!(Ok(TimeBound::Unix(then)), parse_date(" 1522713600 ", tz_utc));
+        assert_eq!(Ok(TimeBound::Unix(then)), parse_date(" 2018-04-03 ", tz_utc));
+        assert_eq!(Ok(TimeBound::Unix(then + hour + min)), parse_date("2018-04-03 01:01", tz_utc));
+        assert_eq!(Ok(TimeBound::Unix(then + hour + min + 1)),
+                   parse_date("2018-04-03 01:01:01", tz_utc));
+        assert_eq!(Ok(TimeBound::Unix(then + hour + min + 1)),
+                   parse_date("2018-04-03T01:01:01", tz_utc));
 
         // Different timezone (not calling `get_utcoffset()` because tests are threaded, which makes
         // `UtcOffset::current_local_offset()` error out)
         for secs in [hour, -1 * hour, 90 * min, -90 * min] {
             let offset = dbg!(UtcOffset::from_whole_seconds(secs.try_into().unwrap()).unwrap());
-            assert_eq!(Ok(then - secs), parse_date("2018-04-03T00:00", offset));
+            assert_eq!(Ok(TimeBound::Unix(then - secs)), parse_date("2018-04-03T00:00", offset));
         }
 
         // Relative dates
-        assert_eq!(Ok(now - hour - 3 * day - 45), parse_date("1 hour, 3 days  45sec", tz_utc));
-        assert_eq!(Ok(now - 5 * 7 * day), parse_date("5 weeks", tz_utc));
+        assert_eq!(Ok(TimeBound::Unix(now - hour - 3 * day - 45)),
+                   parse_date("1 hour, 3 days  45sec", tz_utc));
+        assert_eq!(Ok(TimeBound::Unix(now - 5 * 7 * day)), parse_date("5 weeks", tz_utc));
 
         // Failure cases
         assert!(parse_date("", tz_utc).is_err());

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,7 +5,7 @@ mod proces;
 
 pub use ansi::{Ansi, AnsiStr};
 pub use current::{get_buildlog, get_emerge, get_pretend, get_resume, Pkg};
-pub use history::{get_cmd_times, get_hist, Hist};
+pub use history::{get_hist, Hist};
 #[cfg(test)]
 pub use proces::tests::procs;
 pub use proces::{get_all_proc, FmtProc, ProcKind, ProcList};

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,7 +5,7 @@ mod proces;
 
 pub use ansi::{Ansi, AnsiStr};
 pub use current::{get_buildlog, get_emerge, get_pretend, get_resume, Pkg};
-pub use history::{get_hist, Hist};
+pub use history::{get_cmd_times, get_hist, Hist};
 #[cfg(test)]
 pub use proces::tests::procs;
 pub use proces::{get_all_proc, FmtProc, ProcKind, ProcList};

--- a/src/parse/history.rs
+++ b/src/parse/history.rs
@@ -443,17 +443,20 @@ mod tests {
     }
 
     #[test]
-    /// Basic counts, with every combination of merge/unmerge/sync
+    /// Basic counts, with every combination of command/merge/unmerge/sync
     fn parse_hist_nofilter() {
-        for i in 0..8 {
-            let m = (i & 0b001) == 0;
-            let u = (i & 0b010) == 0;
-            let s = (i & 0b100) == 0;
-            let show = format!("{}{}{}",
+        for i in 0..16 {
+            let c = (i & 0b0001) == 0;
+            let m = (i & 0b0010) == 0;
+            let u = (i & 0b0100) == 0;
+            let s = (i & 0b1000) == 0;
+            let show = format!("{}{}{}{}",
+                               if c { "c" } else { "" },
                                if m { "m" } else { "" },
                                if u { "u" } else { "" },
                                if s { "s" } else { "" });
-            let t = vec![("MStart", if m { 889 } else { 0 }),
+            let t = vec![("CStart", if c { 450 } else { 0 }),
+                         ("MStart", if m { 889 } else { 0 }),
                          ("MStop", if m { 832 } else { 0 }),
                          ("UStart", if u { 832 } else { 0 }),
                          ("UStop", if u { 832 } else { 0 }),

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -100,11 +100,17 @@ fn log() {
                2020-06-18 16:21:56        1 Sync moltonel\n"),
              // Check output of all events
              ("%F10000.log l --show a --from 2018-03-07T10:42:00 --to 2018-03-07T14:00:00 -oc",
-              "2018-03-07 10:43:10    14 >>> sys-apps/the_silver_searcher-2.0.0\n\
+              "2018-03-07 10:42:51       Emerge --backtrack=100 --quiet-build=y sys-apps/the_silver_searcher\n\
+               2018-03-07 10:43:10    14 >>> sys-apps/the_silver_searcher-2.0.0\n\
+               2018-03-07 11:36:27       Emerge --quiet-build=y --sync\n\
                2018-03-07 11:37:05    38 Sync gentoo\n\
+               2018-03-07 11:38:29       Emerge --deep --backtrack=100 --quiet-build=y --ask --update --jobs=2 --newuse --verbose world\n\
                2018-03-07 12:49:09     2 <<< sys-apps/util-linux-2.30.2\n\
                2018-03-07 12:49:13  1:01 >>> sys-apps/util-linux-2.30.2-r1\n\
+               2018-03-07 13:55:29       Emerge --quiet-build=y --sync\n\
                2018-03-07 13:56:09    40 Sync gentoo\n\
+               2018-03-07 13:57:31       Emerge --update --jobs=2 --backtrack=100 --ask --quiet-build=y --verbose --deep --newuse world\n\
+               2018-03-07 13:58:04       Emerge --update --verbose --newuse --quiet-build=y --deep --backtrack=100 world\n\
                2018-03-07 13:59:38     2 <<< dev-libs/nspr-4.17\n\
                2018-03-07 13:59:41    24 >>> dev-libs/nspr-4.18\n"),
              // skip first

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -292,7 +292,9 @@ fn stats() {
               0),
              ("%F10000.log s client -sst -oc", "11  24:00:24  2:10:56  10  27  2\n", 0),
              ("%F10000.log s client -sa -oc",
-              "kde-frameworks/kxmlrpcclient  2        47       23  2   4  2\n\
+              "450  267  20  163\n\
+               \n\
+               kde-frameworks/kxmlrpcclient  2        47       23  2   4  2\n\
                mail-client/thunderbird       2   1:23:44    41:52  2   6  3\n\
                www-client/chromium           3  21:41:24  7:42:07  3  12  3\n\
                www-client/falkon             1      6:02     6:02  0   0  ?\n\
@@ -494,7 +496,7 @@ fn negative_merge_time() {
                        2019-06-05 10:21:02     ? >>> kde-plasma/kwin-5.15.5\n\
                        2019-06-08 21:33:36  3:10 >>> kde-plasma/kwin-5.15.5\n")),
              // For `stats` the negative merge time is used for count but ignored for tottime/predtime.
-             ("%Fnegtime.log s -sa -oc",
+             ("%Fnegtime.log s -sstp -oc",
               format!("gentoo  2  1:06  1:06\n\
                        \n\
                        kde-apps/libktnef  1    26    26  0  0  ?\n\


### PR DESCRIPTION
* log
* stats
* filter

I think that's all the features we can do, given that I couldn't find a reliable enough heuristic to match a command start with a command end.